### PR TITLE
A11y Tree スナップショット機能を追加

### DIFF
--- a/browser_bot.py
+++ b/browser_bot.py
@@ -68,7 +68,9 @@ async def _navigate_to(page, url):
     page.goto() の代わりに window.location.href で遷移する。
     page.goto() は CDP 経由で Chrome をクラッシュさせることがあるため。
     """
-    await page.evaluate(f"() => {{ window.location.href = {json.dumps(url)}; }}")
+    await page.evaluate(
+        f"() => {{ window.location.href = {json.dumps(url)}; }}"
+    )
     await asyncio.sleep(0.5)
 
 
@@ -594,6 +596,179 @@ def _resize_image_if_needed(
     return output.getvalue()
 
 
+# _format_ax_node で使用する定数
+_AX_SKIP_ROLES = frozenset(
+    {
+        'none',
+        'generic',
+        'linebreak',
+        'inlinetextbox',
+    }
+)
+_AX_TEXT_ROLES = frozenset({'statictext', 'text'})
+_AX_INTERACTIVE_ROLES = frozenset(
+    {
+        'button',
+        'link',
+        'textbox',
+        'checkbox',
+        'radio',
+        'combobox',
+        'listbox',
+        'menuitem',
+        'menuitemcheckbox',
+        'menuitemradio',
+        'option',
+        'searchbox',
+        'slider',
+        'spinbutton',
+        'switch',
+        'tab',
+        'treeitem',
+        'scrollbar',
+    }
+)
+
+
+def _format_ax_node(node, ref_map, counter, indent=0):
+    """
+    AX tree ノードを再帰的にテキスト形式に変換し、ref ID を付与する
+
+    Args:
+        node: accessibility.snapshot() が返すノード辞書
+        ref_map: ref ID → ノード情報のマッピング辞書（破壊的に更新）
+        counter: ref ID のカウンター（リスト[int] で参照渡し）
+        indent: 現在のインデント深さ
+
+    Returns:
+        list[str]: フォーマット済みの行リスト
+    """
+    lines = []
+    role = node.get('role', '')
+    name = node.get('name', '')
+    value = node.get('value', '')
+    role_lower = role.lower()
+
+    # 不要なノードをスキップ
+    if role_lower in _AX_SKIP_ROLES and not name:
+        # 子ノードだけ処理
+        for child in node.get('children', []):
+            lines.extend(_format_ax_node(child, ref_map, counter, indent))
+        return lines
+
+    # テキストノードは名前があればインラインで表示
+    if role_lower in _AX_TEXT_ROLES:
+        if name.strip():
+            prefix = '  ' * indent
+            lines.append(f'{prefix}"{name}"')
+        return lines
+
+    # ref ID を付与（操作可能な要素のみ）
+    ref_id = None
+    if role_lower in _AX_INTERACTIVE_ROLES:
+        ref_id = f'@e{counter[0]}'
+        counter[0] += 1
+        ref_map[ref_id] = {
+            'role': role,
+            'name': name,
+        }
+
+    # 行を構築
+    prefix = '  ' * indent
+    parts = []
+    if ref_id:
+        parts.append(f'[{ref_id} {role}]')
+    else:
+        parts.append(f'[{role}]')
+    if name:
+        parts.append(name)
+    if value:
+        parts.append(f'value="{value}"')
+
+    # checked / pressed 状態
+    if node.get('checked') is True:
+        parts.append('(checked)')
+    if node.get('pressed') is True:
+        parts.append('(pressed)')
+    if node.get('disabled') is True:
+        parts.append('(disabled)')
+    if node.get('expanded') is True:
+        parts.append('(expanded)')
+    elif node.get('expanded') is False:
+        parts.append('(collapsed)')
+
+    lines.append(f'{prefix}{" ".join(parts)}')
+
+    # 子ノードを再帰処理
+    for child in node.get('children', []):
+        lines.extend(_format_ax_node(child, ref_map, counter, indent + 1))
+
+    return lines
+
+
+async def get_accessibility_snapshot(*, url: str | None = None):
+    """
+    現在アクティブなタブの A11y Tree スナップショットを取得する
+
+    Args:
+        url: 指定されたらその URL に移動してから取得
+
+    Returns:
+        dict: {
+            'snapshot_text': str,  # ref ID 付きテキストスナップショット
+            'url': str,
+            'title': str,
+            'ref_map': dict,  # ref ID → ノード情報
+        }
+    """
+    logger.info("A11y スナップショット取得開始")
+
+    async with async_playwright() as p:
+        page, browser = await _get_active_page(p, url=url)
+
+        try:
+            current_url = page.url
+            await _page_wait_for_load_state(page)
+
+            try:
+                title = await page.title()
+            except Exception:
+                title = "Unknown"
+
+            # A11y tree を取得
+            ax_tree = await page.accessibility.snapshot(interesting_only=True)
+
+            if not ax_tree:
+                logger.warning("A11y tree が空です")
+                return {
+                    'snapshot_text': '(empty page)',
+                    'url': current_url,
+                    'title': title,
+                    'ref_map': {},
+                }
+
+            # ツリーをテキスト形式に変換
+            ref_map = {}
+            counter = [1]  # リストで参照渡し
+            lines = _format_ax_node(ax_tree, ref_map, counter)
+            snapshot_text = '\n'.join(lines)
+
+            logger.info(
+                f"A11y スナップショット取得完了: {current_url}, "
+                f"ref数={len(ref_map)}, 行数={len(lines)}"
+            )
+
+            return {
+                'snapshot_text': snapshot_text,
+                'url': current_url,
+                'title': title,
+                'ref_map': ref_map,
+            }
+
+        finally:
+            await browser.close()
+
+
 async def get_page_source(*, url: str | None = None):
     """
     現在アクティブなタブのソースコードを取得し、Downloads フォルダに保存する
@@ -692,13 +867,9 @@ async def get_visible_screenshot(
     # スクロール処理
     if page_y_offset_as_viewport_height > 0:
         # ビューポートの高さを取得
-        viewport_height = await page.evaluate(
-            "() => window.innerHeight"
-        )
+        viewport_height = await page.evaluate("() => window.innerHeight")
         # スクロール量を計算
-        scroll_y = int(
-            viewport_height * page_y_offset_as_viewport_height
-        )
+        scroll_y = int(viewport_height * page_y_offset_as_viewport_height)
         # スクロール実行
         await page.evaluate(f"() => window.scrollBy(0, {scroll_y})")
         # スクロール後の描画を待つ
@@ -905,9 +1076,7 @@ async def get_current_url():
     logger.info("現在の URL 取得開始")
 
     p = await async_playwright().start()
-    page, browser = await _get_active_page(
-        p, url=None, create_new_page=False
-    )
+    page, browser = await _get_active_page(p, url=None, create_new_page=False)
 
     try:
         # 現在の状態を取得
@@ -1287,8 +1456,7 @@ async def launch_chrome(*, as_guest: bool = True) -> dict:
 
     if system == "Darwin":
         chrome_paths = [
-            "/Applications/Google Chrome.app/Contents/MacOS/"
-            "Google Chrome",
+            "/Applications/Google Chrome.app/Contents/MacOS/" "Google Chrome",
             "/Applications/Google Chrome Canary.app/Contents/MacOS/"
             "Google Chrome Canary",
             "/Applications/Chromium.app/Contents/MacOS/Chromium",
@@ -1304,8 +1472,7 @@ async def launch_chrome(*, as_guest: bool = True) -> dict:
     elif system == "Windows":
         chrome_paths = [
             r"C:\Program Files\Google\Chrome\Application\chrome.exe",
-            r"C:\Program Files (x86)\Google\Chrome\Application"
-            r"\chrome.exe",
+            r"C:\Program Files (x86)\Google\Chrome\Application" r"\chrome.exe",
         ]
 
     chrome_executable = None
@@ -1331,13 +1498,13 @@ async def launch_chrome(*, as_guest: bool = True) -> dict:
     ]
 
     if as_guest:
-        user_data_dir = os.path.expanduser(
-            "~/.google-chrome-debug-guest"
+        user_data_dir = os.path.expanduser("~/.google-chrome-debug-guest")
+        chrome_args.extend(
+            [
+                f"--user-data-dir={user_data_dir}",
+                "--guest",
+            ]
         )
-        chrome_args.extend([
-            f"--user-data-dir={user_data_dir}",
-            "--guest",
-        ])
     else:
         user_data_dir = os.path.expanduser("~/.google-chrome-debug")
         chrome_args.append(f"--user-data-dir={user_data_dir}")
@@ -1357,9 +1524,7 @@ async def launch_chrome(*, as_guest: bool = True) -> dict:
                 )
                 if response.status_code == 200:
                     version_info = response.json()
-                    browser_info = version_info.get(
-                        'Browser', 'Unknown'
-                    )
+                    browser_info = version_info.get('Browser', 'Unknown')
                     return {
                         'status': 'launched',
                         'message': (
@@ -1385,8 +1550,7 @@ async def launch_chrome(*, as_guest: bool = True) -> dict:
         return {
             'status': 'error',
             'message': (
-                f"Chrome の起動に失敗しました: "
-                f"{e.__class__.__name__}: {e}"
+                f"Chrome の起動に失敗しました: " f"{e.__class__.__name__}: {e}"
             ),
             'browser_info': None,
         }

--- a/browser_bot.py
+++ b/browser_bot.py
@@ -682,7 +682,7 @@ def _format_ax_node(node, ref_map, counter, indent=0):
         parts.append(f'[{role}]')
     if name:
         parts.append(name)
-    if value:
+    if value is not None and value != '':
         parts.append(f'value="{value}"')
 
     # checked / pressed 状態

--- a/browser_bot_cli.py
+++ b/browser_bot_cli.py
@@ -13,6 +13,7 @@ import sys
 
 from browser_bot import (
     BrowserBotError,
+    get_accessibility_snapshot,
     get_current_url,
     get_full_screenshot,
     get_page_source,
@@ -52,6 +53,7 @@ def _print_json(data):
 
 # -- subcommand handlers --
 
+
 def cmd_browser_use(args):
     task_text = _read_stdin_or_exit("タスクテキスト")
     result = asyncio.run(
@@ -64,6 +66,14 @@ def cmd_browser_use(args):
     print(str(result))
 
 
+def cmd_snapshot(args):
+    result = asyncio.run(get_accessibility_snapshot(url=args.url))
+    print(f"# {result['title']}")
+    print(f"URL: {result['url']}")
+    print()
+    print(result['snapshot_text'])
+
+
 def cmd_get_source(args):
     result = asyncio.run(get_page_source(url=args.url))
     _print_json(result)
@@ -73,9 +83,7 @@ def cmd_visible_screenshot(args):
     result = asyncio.run(
         get_visible_screenshot(
             url=args.url,
-            page_y_offset_as_viewport_height=(
-                args.scroll
-            ),
+            page_y_offset_as_viewport_height=(args.scroll),
             include_image_binary=False,
         )
     )
@@ -113,16 +121,12 @@ def cmd_current_url(args):
 
 
 def cmd_super_reload(args):
-    result = asyncio.run(
-        super_reload(url=args.url, mode=args.mode)
-    )
+    result = asyncio.run(super_reload(url=args.url, mode=args.mode))
     _print_json(result)
 
 
 def cmd_launch_chrome(args):
-    result = asyncio.run(
-        launch_chrome(as_guest=not args.no_guest)
-    )
+    result = asyncio.run(launch_chrome(as_guest=not args.no_guest))
     _print_json(result)
 
 
@@ -153,11 +157,13 @@ def cmd_http_request(args):
     else:
         body_text = base64.b64encode(body).decode('utf-8')
 
-    _print_json({
-        "status": response_data['status'],
-        "headers": response_data['headers'],
-        "body": body_text,
-    })
+    _print_json(
+        {
+            "status": response_data['status'],
+            "headers": response_data['headers'],
+            "body": body_text,
+        }
+    )
 
 
 def cmd_login_screenshot(args):
@@ -227,6 +233,14 @@ def build_parser():
     p.add_argument('--url', type=str, default=None)
     p.set_defaults(func=cmd_browser_use)
 
+    # snapshot
+    p = sub.add_parser(
+        'snapshot',
+        help='A11y tree スナップショットを取得 (ref ID 付き)',
+    )
+    p.add_argument('--url', type=str, default=None)
+    p.set_defaults(func=cmd_snapshot)
+
     # get-source
     p = sub.add_parser(
         'get-source',
@@ -242,7 +256,9 @@ def build_parser():
     )
     p.add_argument('--url', type=str, default=None)
     p.add_argument(
-        '--scroll', type=float, default=0.0,
+        '--scroll',
+        type=float,
+        default=0.0,
         help='ビューポート高さの倍率でスクロール (例: 1.0=1ページ分)',
     )
     p.set_defaults(func=cmd_visible_screenshot)
@@ -285,7 +301,9 @@ def build_parser():
     )
     p.add_argument('--url', type=str, default=None)
     p.add_argument(
-        '--mode', type=str, default='cdp',
+        '--mode',
+        type=str,
+        default='cdp',
         choices=['cdp', 'javascript', 'keyboard'],
     )
     p.set_defaults(func=cmd_super_reload)
@@ -296,7 +314,8 @@ def build_parser():
         help='Chrome をデバッグポート付きで起動',
     )
     p.add_argument(
-        '--no-guest', action='store_true',
+        '--no-guest',
+        action='store_true',
         help='通常モードで起動 (デフォルトはゲストモード)',
     )
     p.set_defaults(func=cmd_launch_chrome)
@@ -308,15 +327,24 @@ def build_parser():
     )
     p.add_argument('request_url', help='リクエスト先 URL')
     p.add_argument(
-        '--method', type=str, default='get',
+        '--method',
+        type=str,
+        default='get',
         choices=[
-            'get', 'post', 'put', 'delete',
-            'patch', 'head', 'options',
+            'get',
+            'post',
+            'put',
+            'delete',
+            'patch',
+            'head',
+            'options',
         ],
     )
     p.add_argument('--preload-url', type=str, default=None)
     p.add_argument(
-        '--headers', type=str, default=None,
+        '--headers',
+        type=str,
+        default=None,
         help='HTTP ヘッダー (JSON 文字列)',
     )
     p.set_defaults(func=cmd_http_request)
@@ -328,31 +356,42 @@ def build_parser():
     )
     p.add_argument('--url', type=str, required=True)
     p.add_argument(
-        '--username-selector', type=str,
+        '--username-selector',
+        type=str,
         default='input[name="j_username"]',
     )
     p.add_argument(
-        '--password-selector', type=str,
+        '--password-selector',
+        type=str,
         default='input[name="j_password"]',
     )
     p.add_argument(
-        '--submit-selector', type=str,
+        '--submit-selector',
+        type=str,
         default='button[type="submit"]',
     )
     p.add_argument(
-        '--username-env', type=str, default='JENKINS_USERNAME',
+        '--username-env',
+        type=str,
+        default='JENKINS_USERNAME',
         help='ユーザー名の環境変数名',
     )
     p.add_argument(
-        '--password-env', type=str, default='JENKINS_PASSWORD',
+        '--password-env',
+        type=str,
+        default='JENKINS_PASSWORD',
         help='パスワードの環境変数名',
     )
     p.add_argument(
-        '--env-file', type=str, default=None,
+        '--env-file',
+        type=str,
+        default=None,
         help='追加の .env ファイルパス',
     )
     p.add_argument(
-        '--post-login-wait', type=float, default=3.0,
+        '--post-login-wait',
+        type=float,
+        default=3.0,
         help='ログイン後の待機秒数',
     )
     p.set_defaults(func=cmd_login_screenshot)
@@ -364,11 +403,15 @@ def build_parser():
     )
     p.add_argument('--url', type=str, default=None)
     p.add_argument(
-        '--categories', type=str, default=None,
+        '--categories',
+        type=str,
+        default=None,
         help='カンマ区切り (例: performance,accessibility)',
     )
     p.add_argument(
-        '--device', type=str, default='desktop',
+        '--device',
+        type=str,
+        default='desktop',
         choices=['desktop', 'mobile'],
     )
     p.add_argument('--timeout', type=int, default=120)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -27,6 +27,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 from browser_bot import (
+    get_accessibility_snapshot,
     get_current_url,
     get_full_screenshot,
     get_page_source,
@@ -286,6 +287,51 @@ async def get_page_source_code(
 
     except Exception as e:
         error_msg = f"❌ エラー: ソースコード取得中に予期しないエラーが発生しました: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return error_msg
+
+
+# A11y Tree スナップショット取得ツール
+@server.tool(
+    name="browser_snapshot",
+    description=(
+        "Get accessibility tree snapshot of the current page. "
+        "Returns a text representation with ref IDs (@e1, @e2...) "
+        "for interactive elements. "
+        "Much faster and cheaper than screenshots for understanding "
+        "page structure."
+    ),
+)
+async def browser_snapshot_tool(
+    url: Annotated[
+        str | None,
+        Field(
+            description="Navigate to this URL first, then take snapshot.",
+            examples=["https://example.com"],
+        ),
+    ] = None,
+) -> str:
+    """A11y tree snapshot with ref IDs for interactive elements"""
+    logger.info(f"A11y スナップショットツール実行開始 (URL: {url})")
+
+    try:
+        result = await get_accessibility_snapshot(url=url)
+
+        response_parts = [
+            f"# {result['title']}",
+            f"URL: {result['url']}",
+            "",
+            result['snapshot_text'],
+        ]
+
+        logger.info(f"A11y スナップショットツール完了: {result['url']}")
+        return '\n'.join(response_parts)
+
+    except Exception as e:
+        error_msg = (
+            f"❌ エラー: A11y スナップショット取得中にエラー: "
+            f"{e.__class__.__name__}: {e}"
+        )
         logger.error(error_msg, exc_info=True)
         return error_msg
 

--- a/tests/test-mcp-browser-snapshot.sh
+++ b/tests/test-mcp-browser-snapshot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+# A11y スナップショットツールのテスト
+
+cd $(dirname $0)/../
+
+{
+    echo '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+    sleep 0.5
+    echo '{"jsonrpc": "2.0", "method": "notifications/initialized"}'
+    sleep 0.5
+    echo '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "browser_snapshot", "arguments": {}}}'
+    sleep 5
+} | ./launch-mcp-server.sh
+
+# 終了時に anyio.ClosedResourceError が出るが気にしない


### PR DESCRIPTION
## 概要

Playwright の `page.accessibility.snapshot()` を使用して、ページの構造をアクセシビリティツリーとして取得する機能を追加。

操作可能な要素には ref ID (`@e1`, `@e2`...) を付与し、スクリーンショットより高速・低トークンでページ構造を把握可能にした。

## 変更内容

- `browser_bot.py`: `get_accessibility_snapshot()` 関数、`_format_ax_node()` ヘルパー関数を追加
- `mcp_server.py`: `browser_snapshot` MCP ツールを追加
- `browser_bot_cli.py`: `snapshot` サブコマンドを追加

## 出力例 (google.com)

```
[WebArea] Google
  [@e1 link] Googleについて
  [@e2 link] ストア
  [@e3 button] Google アプリ
  [@e4 link] ログイン
  [image] Google
  [@e5 combobox] 検索
  [@e6 button] 音声で検索
  [@e7 button] 画像で検索
  [@e8 button] Google 検索
  [@e9 button] I'm Feeling Lucky
  "Google 検索は次の言語でもご利用いただけます: "
  [@e10 link] English
```

## テスト

- `browser-bot snapshot --url https://www.google.com` で動作確認済み
- `browser-bot snapshot --url https://github.com` で複雑なページ (107 ref IDs) も正常取得確認